### PR TITLE
Various updates to create a prototype ability to enable yaml files for commands

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"flag"
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -40,6 +42,150 @@ func TestCommandIgnoreFlags(t *testing.T) {
 		Description:     "testing",
 		Action:          func(_ *Context) {},
 		SkipFlagParsing: true,
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTest(t *testing.T) {
+	app := NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := NewContext(app, set, nil)
+
+	command := Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *Context) {
+			val := c.Int("test")
+			expect(t, val, 15)
+		},
+		UseYaml: true,
+		Flags:   []Flag{IntFlag{Name: "test"}},
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestGlobalEnvVarWins(t *testing.T) {
+	app := NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	os.Setenv("THE_TEST", "10")
+	defer os.Setenv("THE_TEST", "")
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := NewContext(app, set, nil)
+
+	command := Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *Context) {
+			val := c.Int("test")
+			expect(t, val, 10)
+		},
+		UseYaml: true,
+		Flags:   []Flag{IntFlag{Name: "test", EnvVar: "THE_TEST"}},
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestSpecifiedFlagWins(t *testing.T) {
+	app := NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	test := []string{"test-cmd", "--load", "current.yaml", "--test", "7"}
+	set.Parse(test)
+
+	c := NewContext(app, set, nil)
+
+	command := Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *Context) {
+			val := c.Int("test")
+			expect(t, val, 7)
+		},
+		UseYaml: true,
+		Flags:   []Flag{IntFlag{Name: "test"}},
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileTestDefaultValueFileWins(t *testing.T) {
+	app := NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := NewContext(app, set, nil)
+
+	command := Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *Context) {
+			val := c.Int("test")
+			expect(t, val, 15)
+		},
+		UseYaml: true,
+		Flags:   []Flag{IntFlag{Name: "test", Value: 7}},
+	}
+	err := command.Run(c)
+
+	expect(t, err, nil)
+}
+
+func TestCommandYamlFileFlagHasDefaultGlobalEnvYamlSetGlobalEnvWins(t *testing.T) {
+	app := NewApp()
+	set := flag.NewFlagSet("test", 0)
+	ioutil.WriteFile("current.yaml", []byte("test: 15"), 0666)
+	defer os.Remove("current.yaml")
+
+	os.Setenv("THE_TEST", "11")
+	defer os.Setenv("THE_TEST", "")
+
+	test := []string{"test-cmd", "--load", "current.yaml"}
+	set.Parse(test)
+
+	c := NewContext(app, set, nil)
+
+	command := Command{
+		Name:        "test-cmd",
+		Aliases:     []string{"tc"},
+		Usage:       "this is for testing",
+		Description: "testing",
+		Action: func(c *Context) {
+			val := c.Int("test")
+			expect(t, val, 11)
+		},
+		UseYaml: true,
+		Flags:   []Flag{IntFlag{Name: "test", Value: 7, EnvVar: "THE_TEST"}},
 	}
 	err := command.Run(c)
 

--- a/context.go
+++ b/context.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"flag"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -15,149 +14,133 @@ import (
 type Context struct {
 	App            *App
 	Command        Command
-	flagSet        *flag.FlagSet
-	setFlags       map[string]bool
-	globalSetFlags map[string]bool
+	flagSetManager FlagSetManager
 	parentContext  *Context
 }
 
 // Creates a new context. For use in when invoking an App or Command action.
 func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
-	return &Context{App: app, flagSet: set, parentContext: parentCtx}
+	return &Context{App: app, flagSetManager: NewFlagSetManager(set), parentContext: parentCtx}
 }
 
 // Looks up the value of a local int flag, returns 0 if no int flag exists
 func (c *Context) Int(name string) int {
-	return lookupInt(name, c.flagSet)
+	return c.flagSetManager.Int(name)
 }
 
 // Looks up the value of a local time.Duration flag, returns 0 if no time.Duration flag exists
 func (c *Context) Duration(name string) time.Duration {
-	return lookupDuration(name, c.flagSet)
+	return c.flagSetManager.Duration(name)
 }
 
 // Looks up the value of a local float64 flag, returns 0 if no float64 flag exists
 func (c *Context) Float64(name string) float64 {
-	return lookupFloat64(name, c.flagSet)
+	return c.flagSetManager.Float64(name)
 }
 
 // Looks up the value of a local bool flag, returns false if no bool flag exists
 func (c *Context) Bool(name string) bool {
-	return lookupBool(name, c.flagSet)
+	return c.flagSetManager.Bool(name)
 }
 
 // Looks up the value of a local boolT flag, returns false if no bool flag exists
 func (c *Context) BoolT(name string) bool {
-	return lookupBoolT(name, c.flagSet)
+	return c.flagSetManager.BoolT(name)
 }
 
 // Looks up the value of a local string flag, returns "" if no string flag exists
 func (c *Context) String(name string) string {
-	return lookupString(name, c.flagSet)
+	return c.flagSetManager.String(name)
 }
 
 // Looks up the value of a local string slice flag, returns nil if no string slice flag exists
 func (c *Context) StringSlice(name string) []string {
-	return lookupStringSlice(name, c.flagSet)
+	return c.flagSetManager.StringSlice(name)
 }
 
 // Looks up the value of a local int slice flag, returns nil if no int slice flag exists
 func (c *Context) IntSlice(name string) []int {
-	return lookupIntSlice(name, c.flagSet)
+	return c.flagSetManager.IntSlice(name)
 }
 
 // Looks up the value of a local generic flag, returns nil if no generic flag exists
 func (c *Context) Generic(name string) interface{} {
-	return lookupGeneric(name, c.flagSet)
+	return c.flagSetManager.Generic(name)
 }
 
 // Looks up the value of a global int flag, returns 0 if no int flag exists
 func (c *Context) GlobalInt(name string) int {
-	if fs := lookupGlobalFlagSet(name, c); fs != nil {
-		return lookupInt(name, fs)
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.Int(name)
 	}
 	return 0
 }
 
 // Looks up the value of a global time.Duration flag, returns 0 if no time.Duration flag exists
 func (c *Context) GlobalDuration(name string) time.Duration {
-	if fs := lookupGlobalFlagSet(name, c); fs != nil {
-		return lookupDuration(name, fs)
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.Duration(name)
 	}
 	return 0
 }
 
 // Looks up the value of a global bool flag, returns false if no bool flag exists
 func (c *Context) GlobalBool(name string) bool {
-	if fs := lookupGlobalFlagSet(name, c); fs != nil {
-		return lookupBool(name, fs)
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.Bool(name)
 	}
 	return false
 }
 
 // Looks up the value of a global string flag, returns "" if no string flag exists
 func (c *Context) GlobalString(name string) string {
-	if fs := lookupGlobalFlagSet(name, c); fs != nil {
-		return lookupString(name, fs)
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.String(name)
 	}
 	return ""
 }
 
 // Looks up the value of a global string slice flag, returns nil if no string slice flag exists
 func (c *Context) GlobalStringSlice(name string) []string {
-	if fs := lookupGlobalFlagSet(name, c); fs != nil {
-		return lookupStringSlice(name, fs)
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.StringSlice(name)
 	}
 	return nil
 }
 
 // Looks up the value of a global int slice flag, returns nil if no int slice flag exists
 func (c *Context) GlobalIntSlice(name string) []int {
-	if fs := lookupGlobalFlagSet(name, c); fs != nil {
-		return lookupIntSlice(name, fs)
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.IntSlice(name)
 	}
 	return nil
 }
 
 // Looks up the value of a global generic flag, returns nil if no generic flag exists
 func (c *Context) GlobalGeneric(name string) interface{} {
-	if fs := lookupGlobalFlagSet(name, c); fs != nil {
-		return lookupGeneric(name, fs)
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.Generic(name)
 	}
 	return nil
 }
 
 // Returns the number of flags set
 func (c *Context) NumFlags() int {
-	return c.flagSet.NFlag()
+	return c.flagSetManager.NumFlags()
 }
 
 // Determines if the flag was actually set
 func (c *Context) IsSet(name string) bool {
-	if c.setFlags == nil {
-		c.setFlags = make(map[string]bool)
-		c.flagSet.Visit(func(f *flag.Flag) {
-			c.setFlags[f.Name] = true
-		})
-	}
-	return c.setFlags[name] == true
+	return c.flagSetManager.IsSet(name)
 }
 
 // Determines if the global flag was actually set
 func (c *Context) GlobalIsSet(name string) bool {
-	if c.globalSetFlags == nil {
-		c.globalSetFlags = make(map[string]bool)
-		ctx := c
-		if ctx.parentContext != nil {
-			ctx = ctx.parentContext
-		}
-		for ; ctx != nil && c.globalSetFlags[name] == false; ctx = ctx.parentContext {
-			ctx.flagSet.Visit(func(f *flag.Flag) {
-				c.globalSetFlags[f.Name] = true
-			})
-		}
+	if fsm := lookupGlobalFlagSetManager(name, c); fsm != nil {
+		return fsm.IsSet(name)
 	}
-	return c.globalSetFlags[name]
+
+	return false
 }
 
 // Returns a slice of flag names used in this context.
@@ -193,8 +176,7 @@ type Args []string
 
 // Returns the command line arguments associated with the context.
 func (c *Context) Args() Args {
-	args := Args(c.flagSet.Args())
-	return args
+	return c.flagSetManager.Args()
 }
 
 // Returns the nth argument, or else a blank string
@@ -233,117 +215,16 @@ func (a Args) Swap(from, to int) error {
 	return nil
 }
 
-func lookupGlobalFlagSet(name string, ctx *Context) *flag.FlagSet {
+func lookupGlobalFlagSetManager(name string, ctx *Context) FlagSetManager {
 	if ctx.parentContext != nil {
 		ctx = ctx.parentContext
 	}
 	for ; ctx != nil; ctx = ctx.parentContext {
-		if f := ctx.flagSet.Lookup(name); f != nil {
-			return ctx.flagSet
+		if ctx.flagSetManager.HasFlag(name) {
+			return ctx.flagSetManager
 		}
 	}
 	return nil
-}
-
-func lookupInt(name string, set *flag.FlagSet) int {
-	f := set.Lookup(name)
-	if f != nil {
-		val, err := strconv.Atoi(f.Value.String())
-		if err != nil {
-			return 0
-		}
-		return val
-	}
-
-	return 0
-}
-
-func lookupDuration(name string, set *flag.FlagSet) time.Duration {
-	f := set.Lookup(name)
-	if f != nil {
-		val, err := time.ParseDuration(f.Value.String())
-		if err == nil {
-			return val
-		}
-	}
-
-	return 0
-}
-
-func lookupFloat64(name string, set *flag.FlagSet) float64 {
-	f := set.Lookup(name)
-	if f != nil {
-		val, err := strconv.ParseFloat(f.Value.String(), 64)
-		if err != nil {
-			return 0
-		}
-		return val
-	}
-
-	return 0
-}
-
-func lookupString(name string, set *flag.FlagSet) string {
-	f := set.Lookup(name)
-	if f != nil {
-		return f.Value.String()
-	}
-
-	return ""
-}
-
-func lookupStringSlice(name string, set *flag.FlagSet) []string {
-	f := set.Lookup(name)
-	if f != nil {
-		return (f.Value.(*StringSlice)).Value()
-
-	}
-
-	return nil
-}
-
-func lookupIntSlice(name string, set *flag.FlagSet) []int {
-	f := set.Lookup(name)
-	if f != nil {
-		return (f.Value.(*IntSlice)).Value()
-
-	}
-
-	return nil
-}
-
-func lookupGeneric(name string, set *flag.FlagSet) interface{} {
-	f := set.Lookup(name)
-	if f != nil {
-		return f.Value
-	}
-	return nil
-}
-
-func lookupBool(name string, set *flag.FlagSet) bool {
-	f := set.Lookup(name)
-	if f != nil {
-		val, err := strconv.ParseBool(f.Value.String())
-		if err != nil {
-			return false
-		}
-		return val
-	}
-
-	return false
-}
-
-func lookupBoolT(name string, set *flag.FlagSet) bool {
-	f := set.Lookup(name)
-	if f != nil {
-		val, err := strconv.ParseBool(f.Value.String())
-		if err != nil {
-			return true
-		}
-		return val
-	}
-
-	return false
 }
 
 func copyFlag(name string, ff *flag.Flag, set *flag.FlagSet) {

--- a/context.go
+++ b/context.go
@@ -18,9 +18,14 @@ type Context struct {
 	parentContext  *Context
 }
 
+// Creates a new context using a FlagSetManager for redirection when invoking an App or Command action.
+func NewContextWithFlagSetManager(app *App, fsm FlagSetManager, parentCtx *Context) *Context {
+	return &Context{App: app, flagSetManager: fsm, parentContext: parentCtx}
+}
+
 // Creates a new context. For use in when invoking an App or Command action.
 func NewContext(app *App, set *flag.FlagSet, parentCtx *Context) *Context {
-	return &Context{App: app, flagSetManager: NewFlagSetManager(set), parentContext: parentCtx}
+	return &Context{App: app, flagSetManager: NewFlagSetManager(set, nil), parentContext: parentCtx}
 }
 
 // Looks up the value of a local int flag, returns 0 if no int flag exists

--- a/context_test.go
+++ b/context_test.go
@@ -87,10 +87,12 @@ func TestContext_GlobalIsSet(t *testing.T) {
 	globalSet := flag.NewFlagSet("test", 0)
 	globalSet.Bool("myflagGlobal", true, "doc")
 	globalSet.Bool("myflagGlobalUnset", true, "doc")
+
 	globalCtx := NewContext(nil, globalSet, nil)
 	c := NewContext(nil, set, globalCtx)
 	set.Parse([]string{"--myflag", "bat", "baz"})
 	globalSet.Parse([]string{"--myflagGlobal", "bat", "baz"})
+
 	expect(t, c.GlobalIsSet("myflag"), false)
 	expect(t, c.GlobalIsSet("otherflag"), false)
 	expect(t, c.GlobalIsSet("bogusflag"), false)

--- a/flag.go
+++ b/flag.go
@@ -14,6 +14,11 @@ var BashCompletionFlag = BoolFlag{
 	Name: "generate-bash-completion",
 }
 
+var LoadFileFlag = StringFlag{
+	Name:  "load",
+	Usage: "information to load from alternate input source",
+}
+
 // This flag prints the version for the application
 var VersionFlag = BoolFlag{
 	Name:  "version, v",
@@ -36,14 +41,16 @@ type Flag interface {
 	// Apply Flag settings to the given flag set
 	Apply(*flag.FlagSet)
 	getName() string
+	getEnvVar() string
+	getHasDefaultValue() bool
 }
 
 func flagSet(name string, flags []Flag) *flag.FlagSet {
 	set := flag.NewFlagSet(name, flag.ContinueOnError)
-
 	for _, f := range flags {
 		f.Apply(set)
 	}
+
 	return set
 }
 
@@ -93,6 +100,18 @@ func (f GenericFlag) Apply(set *flag.FlagSet) {
 	eachName(f.Name, func(name string) {
 		set.Var(f.Value, name, f.Usage)
 	})
+}
+
+func (f GenericFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f GenericFlag) getHasDefaultValue() bool {
+	if f.Value.String() != "" {
+		return true
+	}
+
+	return false
 }
 
 func (f GenericFlag) getName() string {
@@ -161,6 +180,18 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 
 func (f StringSliceFlag) getName() string {
 	return f.Name
+}
+
+func (f StringSliceFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f StringSliceFlag) getHasDefaultValue() bool {
+	if f.Value != nil {
+		return true
+	}
+
+	return false
 }
 
 // StringSlice is an opaque type for []int to satisfy flag.Value
@@ -235,6 +266,18 @@ func (f IntSliceFlag) getName() string {
 	return f.Name
 }
 
+func (f IntSliceFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f IntSliceFlag) getHasDefaultValue() bool {
+	if f.Value != nil {
+		return true
+	}
+
+	return false
+}
+
 // BoolFlag is a switch that defaults to false
 type BoolFlag struct {
 	Name        string
@@ -275,6 +318,14 @@ func (f BoolFlag) Apply(set *flag.FlagSet) {
 
 func (f BoolFlag) getName() string {
 	return f.Name
+}
+
+func (f BoolFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f BoolFlag) getHasDefaultValue() bool {
+	return false
 }
 
 // BoolTFlag this represents a boolean flag that is true by default, but can
@@ -318,6 +369,14 @@ func (f BoolTFlag) Apply(set *flag.FlagSet) {
 
 func (f BoolTFlag) getName() string {
 	return f.Name
+}
+
+func (f BoolTFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f BoolTFlag) getHasDefaultValue() bool {
+	return false
 }
 
 // StringFlag represents a flag that takes as string value
@@ -368,6 +427,14 @@ func (f StringFlag) getName() string {
 	return f.Name
 }
 
+func (f StringFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f StringFlag) getHasDefaultValue() bool {
+	return false
+}
+
 // IntFlag is a flag that takes an integer
 // Errors if the value provided cannot be parsed
 type IntFlag struct {
@@ -409,6 +476,14 @@ func (f IntFlag) Apply(set *flag.FlagSet) {
 
 func (f IntFlag) getName() string {
 	return f.Name
+}
+
+func (f IntFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f IntFlag) getHasDefaultValue() bool {
+	return f.Value > 0
 }
 
 // DurationFlag is a flag that takes a duration specified in Go's duration
@@ -454,6 +529,14 @@ func (f DurationFlag) getName() string {
 	return f.Name
 }
 
+func (f DurationFlag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f DurationFlag) getHasDefaultValue() bool {
+	return f.Value > 0
+}
+
 // Float64Flag is a flag that takes an float value
 // Errors if the value provided cannot be parsed
 type Float64Flag struct {
@@ -494,6 +577,14 @@ func (f Float64Flag) Apply(set *flag.FlagSet) {
 
 func (f Float64Flag) getName() string {
 	return f.Name
+}
+
+func (f Float64Flag) getEnvVar() string {
+	return f.EnvVar
+}
+
+func (f Float64Flag) getHasDefaultValue() bool {
+	return f.Value > 0
 }
 
 func prefixFor(name string) (prefix string) {

--- a/flag_set_manager.go
+++ b/flag_set_manager.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"flag"
+	"strconv"
+	"time"
+)
+
+type FlagSetManager interface {
+	HasFlag(name string) bool
+	IsSet(name string) bool
+	NumFlags() int
+	Args() Args
+	Int(name string) int
+	Duration(name string) time.Duration
+	Float64(name string) float64
+	String(name string) string
+	StringSlice(name string) []string
+	IntSlice(name string) []int
+	Generic(name string) interface{}
+	Bool(name string) bool
+	BoolT(name string) bool
+}
+
+// Context is a type that is passed through to
+// each Handler action in a cli application. Context
+// can be used to retrieve context-specific Args and
+// parsed command-line options.
+type DefaultFlagSetManager struct {
+	set      *flag.FlagSet
+	setFlags map[string]bool
+}
+
+func NewFlagSetManager(set *flag.FlagSet) FlagSetManager {
+	return &DefaultFlagSetManager{set: set}
+}
+
+// Determines if the flag was actually set
+func (fsm *DefaultFlagSetManager) HasFlag(name string) bool {
+	if fsm.set.Lookup(name) != nil {
+		return true
+	}
+	return false
+}
+
+// Determines if the flag was actually set
+func (fsm *DefaultFlagSetManager) IsSet(name string) bool {
+	if fsm.setFlags == nil {
+		fsm.setFlags = make(map[string]bool)
+		fsm.set.Visit(func(f *flag.Flag) {
+			fsm.setFlags[f.Name] = true
+		})
+	}
+	return fsm.setFlags[name] == true
+}
+
+// Returns the number of flags set
+func (fsm *DefaultFlagSetManager) NumFlags() int {
+	return fsm.set.NFlag()
+}
+
+// Returns the command line arguments associated with the context.
+func (fsm *DefaultFlagSetManager) Args() Args {
+	args := Args(fsm.set.Args())
+	return args
+}
+
+func (fsm *DefaultFlagSetManager) Int(name string) int {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		val, err := strconv.Atoi(f.Value.String())
+		if err != nil {
+			return 0
+		}
+		return val
+	}
+
+	return 0
+}
+
+func (fsm *DefaultFlagSetManager) Duration(name string) time.Duration {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		val, err := time.ParseDuration(f.Value.String())
+		if err == nil {
+			return val
+		}
+	}
+
+	return 0
+}
+
+func (fsm *DefaultFlagSetManager) Float64(name string) float64 {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		val, err := strconv.ParseFloat(f.Value.String(), 64)
+		if err != nil {
+			return 0
+		}
+		return val
+	}
+
+	return 0
+}
+
+func (fsm *DefaultFlagSetManager) String(name string) string {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		return f.Value.String()
+	}
+
+	return ""
+}
+
+func (fsm *DefaultFlagSetManager) StringSlice(name string) []string {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		return (f.Value.(*StringSlice)).Value()
+
+	}
+
+	return nil
+}
+
+func (fsm *DefaultFlagSetManager) IntSlice(name string) []int {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		return (f.Value.(*IntSlice)).Value()
+
+	}
+
+	return nil
+}
+
+func (fsm *DefaultFlagSetManager) Generic(name string) interface{} {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		return f.Value
+	}
+	return nil
+}
+
+func (fsm *DefaultFlagSetManager) Bool(name string) bool {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		val, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return false
+		}
+		return val
+	}
+
+	return false
+}
+
+func (fsm *DefaultFlagSetManager) BoolT(name string) bool {
+	f := fsm.set.Lookup(name)
+	if f != nil {
+		val, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return true
+		}
+		return val
+	}
+
+	return false
+}

--- a/map_flag_set_manager.go
+++ b/map_flag_set_manager.go
@@ -1,0 +1,149 @@
+// Context is a type that is passed through to
+package cli
+
+import "time"
+
+type MapFlagSetManager struct {
+	wrappedFsm FlagSetManager
+	valueMap   map[string]interface{}
+}
+
+// Determines if the flag was actually set
+func (fsm *MapFlagSetManager) HasFlag(name string) bool {
+	return fsm.wrappedFsm.HasFlag(name)
+}
+
+func (fsm *MapFlagSetManager) IsDefaultValueSet(name string) bool {
+	return fsm.wrappedFsm.IsDefaultValueSet(name)
+}
+
+func (fsm *MapFlagSetManager) IsEnvVarSet(name string) bool {
+	return fsm.wrappedFsm.IsEnvVarSet(name)
+}
+
+// Determines if the flag was actually set
+func (fsm *MapFlagSetManager) IsSet(name string) bool {
+	if fsm.wrappedFsm.IsSet(name) {
+		return true
+	}
+
+	_, exists := fsm.valueMap[name]
+	return exists
+}
+
+// Returns the number of flags set
+func (fsm *MapFlagSetManager) NumFlags() int {
+	return fsm.wrappedFsm.NumFlags()
+}
+
+// Returns the command line arguments associated with the context.
+func (fsm *MapFlagSetManager) Args() Args {
+	return fsm.wrappedFsm.Args()
+}
+
+var intValue = 1
+
+func (fsm *MapFlagSetManager) Int(name string) int {
+	value := fsm.wrappedFsm.Int(name)
+	if !fsm.IsEnvVarSet(name) && (value == 0 || fsm.wrappedFsm.IsDefaultValueSet(name)) {
+		otherValue, isType := fsm.valueMap[name].(int)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) Duration(name string) time.Duration {
+	value := fsm.wrappedFsm.Duration(name)
+	if !fsm.IsEnvVarSet(name) && (value == 0 || fsm.wrappedFsm.IsDefaultValueSet(name)) {
+		otherValue, isType := fsm.valueMap[name].(time.Duration)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) Float64(name string) float64 {
+	value := fsm.wrappedFsm.Float64(name)
+	if !fsm.IsEnvVarSet(name) && (value == 0 || fsm.wrappedFsm.IsDefaultValueSet(name)) {
+		otherValue, isType := fsm.valueMap[name].(float64)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) String(name string) string {
+	value := fsm.wrappedFsm.String(name)
+	if !fsm.IsEnvVarSet(name) && (value == "" || fsm.wrappedFsm.IsDefaultValueSet(name)) {
+		otherValue, isType := fsm.valueMap[name].(string)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) StringSlice(name string) []string {
+	value := fsm.wrappedFsm.StringSlice(name)
+	if !fsm.IsEnvVarSet(name) && (value == nil || fsm.wrappedFsm.IsDefaultValueSet(name)) {
+		otherValue, isType := fsm.valueMap[name].([]string)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) IntSlice(name string) []int {
+	value := fsm.wrappedFsm.IntSlice(name)
+	if !fsm.IsEnvVarSet(name) && (value == nil || fsm.wrappedFsm.IsDefaultValueSet(name)) {
+		otherValue, isType := fsm.valueMap[name].([]int)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) Generic(name string) interface{} {
+	value := fsm.wrappedFsm.Generic(name)
+	if !fsm.IsEnvVarSet(name) && (value == nil || fsm.wrappedFsm.IsDefaultValueSet(name)) {
+		return fsm.valueMap[name].(time.Duration)
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) Bool(name string) bool {
+	value := fsm.wrappedFsm.Bool(name)
+	if !fsm.IsEnvVarSet(name) && !value {
+		otherValue, isType := fsm.valueMap[name].(bool)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}
+
+func (fsm *MapFlagSetManager) BoolT(name string) bool {
+	value := fsm.wrappedFsm.BoolT(name)
+	if !fsm.IsEnvVarSet(name) && value {
+		otherValue, isType := fsm.valueMap[name].(bool)
+		if isType {
+			return otherValue
+		}
+	}
+
+	return value
+}

--- a/yaml_source_loader.go
+++ b/yaml_source_loader.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type YamlSourceLoader struct {
+	FilePath string
+}
+
+func (ysl *YamlSourceLoader) Load() (map[string]interface{}, error) {
+	var results map[string]interface{}
+	err := readCommandYaml(ysl.FilePath, &results)
+	return results, err
+}
+
+func readCommandYaml(filePath string, container interface{}) (err error) {
+	b, err := loadDataFrom(filePath)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(b, container)
+	if err != nil {
+		return err
+	}
+
+	err = nil
+	return
+}
+
+func loadDataFrom(filePath string) ([]byte, error) {
+	u, err := url.Parse(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Host != "" { // i have a host, now do i support the scheme?
+		switch u.Scheme {
+		case "http", "https":
+			res, err := http.Get(filePath)
+			if err != nil {
+				return nil, err
+			}
+			return ioutil.ReadAll(res.Body)
+		default:
+			return nil, fmt.Errorf("scheme of %s is unsupported", filePath)
+		}
+	} else if u.Path != "" { // i dont have a host, but I have a path. I am a local file.
+		if _, notFoundFileErr := os.Stat(filePath); notFoundFileErr != nil {
+			return nil, fmt.Errorf("Cannot read from file: '%s' because it does not exist.", filePath)
+		}
+		return ioutil.ReadFile(filePath)
+	} else {
+		return nil, fmt.Errorf("unable to determine how to load from path %s", filePath)
+	}
+}


### PR DESCRIPTION
Just exploring some options. The one thing that has been the biggest pain is dealing with the cli.Context because the values are coming from the flagset. Previously values would need to be injected in there. I didn't really like this because for files, the values could already be in the format needed (an int, duration, etc) and I didn't want to have to convert to a string to input into the flagset only to get it back out. 

I'm not aiming to merge this into other forks, just putting it out there for comments. I think refactoring the cli.Context would allow more options that is present at extending the current functionality.
